### PR TITLE
Use only SNVs so we can use dbSNP identifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ intermediate/
 output/
 playground/
 .snakemake*
+.DS_Store

--- a/Snakefile
+++ b/Snakefile
@@ -1,4 +1,6 @@
 """Snakemake workflow documenting BIOSTAT 666 project
+
+Note: 1K Genomes to PLINK Modified from https://www.biostars.org/p/335605/
 """
 
 from pathlib import Path
@@ -9,19 +11,20 @@ STUDIES = ["adhd_jul2017","ocd_aug2017"]
 VCF_DIR = Path("input/vcf")
 ASSOC_DIR = Path("input/gwas")
 INT_DIR = Path("intermediate/")
-REF_FASTA = Path("input/human_g1k_v37.fasta")
 OUT_DIR = Path("output/")
+
+# Rule to filter VCF to only SNVs, 
 rule norm_vcf:
-    input: vcf=VCF_DIR / "ALL.chr{chr}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz",ref=REF_FASTA
+    input: vcf=VCF_DIR / "ALL.chr{chr}.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz"
     output: INT_DIR / "chr{chr}_normed.bcf"
     shell:
         """
         mkdir -p $(dirname {output})
-        bcftools norm -m-any --check-ref w -f {input.ref} {input.vcf} | \
-        bcftools annotate -x ID -I +'%CHROM:%POS:%REF:%ALT' | \
-        bcftools norm -Ob --rm-dup both > {output}
+        bcftools view -v snps {input.vcf} | bcftools norm -Ob --rm-dup both > {output}
         bcftools index {output}
         """
+
+# Rule to convert BCF to PLINK format
 rule vcf_to_plink:
     input: rules.norm_vcf.output
     output: INT_DIR/"chr{chr}.bed"
@@ -31,26 +34,24 @@ rule vcf_to_plink:
          --keep-allele-order --vcf-idspace-to _ --const-fid --allow-extra-chr 0 --split-x b37 no-fail --make-bed \
         --out {INT_DIR}/chr{wildcards.chr}
         """
-rule reformat_assoc:
-    input: ASSOC_DIR = ASSOC_DIR / "{study}"
-    output: INT_DIR / "{study}_normed.assoc"
-    shell:
-        """
-        awk 'NR==1; NR>1 {{$2 = $1":"$3":"$5":"$4; print}}' {input} > {output} 
-        """
+
+# Merge PLINK chromosome files
 rule merge_chroms:
     input: expand(rules.vcf_to_plink.output,chr=CHROMS_INCLUDED)
     output: INT_DIR / "merged.bed"
     shell:
         """
+        rm -f {INT_DIR}/merge_list
         for line in {CHROMS_INCLUDED}
         do
-            echo "{INT_DIR}/chr$line \n" >> {INT_DIR}/merge_list
+            echo "{INT_DIR}/chr$line" >> {INT_DIR}/merge_list
         done
         plink --merge-list {INT_DIR}/merge_list --out {INT_DIR}/merged
         """
+
+# Joint clumping of SNPs
 rule clump_snps:
-    input: data=rules.merge_chroms.output, asso=expand(rules.reformat_assoc.output,study=STUDIES)
+    input: data=rules.merge_chroms.output, asso=expand(str(ASSOC_DIR / "{study}"),study=STUDIES)
     output: OUT_DIR / "gwas_snps.clumped"
     shell:
         """


### PR DESCRIPTION
Updates `Snakefile` to use rs ids as identifers between 1K genomes dataset and GWAS summary statistics. Requires de-duping the VCF and only using SNVs to ensure uniqueness.  